### PR TITLE
Pagination index removed

### DIFF
--- a/dpoll/templates/index.html
+++ b/dpoll/templates/index.html
@@ -56,9 +56,6 @@
                 <span class="page-link">&laquo;  Previous</span>
               </li>
             {% endif %}
-            <li class="page-item">
-              <a class="page-link" href="#">{{ polls.number }}</a>
-            </li>
             {% if polls.has_next %}
               <li class="page-item">
                 <a href="?page={{ polls.next_page_number }}" class="page-link next">Next  &raquo;</a>


### PR DESCRIPTION
Recent polls pagination index removed.

Desktop:
<img width="1158" alt="screen shot 2018-11-12 at 22 22 04" src="https://user-images.githubusercontent.com/10615529/48370218-b425ef00-e6c9-11e8-812c-0a0e311aa3ad.png">
